### PR TITLE
Correct the var name for disabling pw at boot requirement.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -60,8 +60,8 @@ ubuntu2004cis_rule_1_3_3: true
 ubuntu2004cis_rule_1_4_1: true
 ubuntu2004cis_rule_1_4_2: true
 ubuntu2004cis_rule_1_5_1: true
+ubuntu2004cis_rule_1_5_1_disable_password: true
 ubuntu2004cis_rule_1_5_2: true
-ubuntu2004cis_rule_1_5_2_disable_password: true
 ubuntu2004cis_rule_1_5_3: false
 ubuntu2004cis_rule_1_5_4: true
 ubuntu2004cis_rule_1_6_1: true


### PR DESCRIPTION
Under 20.04 'Ensure bootloader password is set' is 1.5.1, rather than 1.5.2.