### PR TITLE
5.3.2: missing common-account task

### DIFF
--- a/tasks/section5.yml
+++ b/tasks/section5.yml
@@ -572,9 +572,16 @@
       - rule_5.3.1
 
 - name: "SCORED | 5.3.2 | PATCH | Ensure lockout for failed password attempts is configured"
-  lineinfile:
-      dest: /etc/pam.d/common-auth
-      line: 'auth required pam_tally2.so onerr=fail audit silent deny=5 unlock_time=900'
+  block:
+      - name: "SCORED | 5.3.2 | PATCH |  Ensure lockout for failed password attempts is configured - /etc/pam.d/common-account"
+        lineinfile:
+            dest: /etc/pam.d/common-account
+            line: 'account required pam_tally2.so'
+
+      - name: "SCORED | 5.3.2 | PATCH |  Ensure lockout for failed password attempts is configured - /etc/pam.d/common-auth"
+        lineinfile:
+            dest: /etc/pam.d/common-auth
+            line: 'auth required pam_tally2.so onerr=fail audit silent deny=5 unlock_time=900'
   when:
       - ubuntu2004cis_rule_5_3_2
   tags:


### PR DESCRIPTION
According to the 5.3.2 section it's also needed `account required pam_tally2.so` in the /etc/pam.d/common-account files
Without this line Pam_tally2 counter increases every time sudo is used