### PR TITLE
rule 4.4 is too restrictive

### DIFF
--- a/tasks/section4.yml
+++ b/tasks/section4.yml
@@ -612,7 +612,7 @@
       state: present
       dest: /etc/logrotate.conf
       regexp: '^create'
-      line: 'create 0640 root utmp'
+      line: 'create 0640'
   when:
       - ubuntu2004cis_rule_4_4
   tags:


### PR DESCRIPTION
`create 0640 root utmp` create not writable files ... at least related to _/etc/logrotate.d/rsyslog_ 
a the moment a more conservative option is `create 0640`