### PR TITLE
make chrony user system-dependent

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -480,6 +480,9 @@ tmp_mount_options:
 chrony_config_file:
   RedHat: /etc/chrony.conf
   Debian: /etc/chrony/chrony.conf
+chrony_system_user:
+  RedHat: chrony
+  Debian: _chrony
 
 ### Firewall
 ubuntu2004cis_setup_firewall: false

--- a/tasks/section2.yml
+++ b/tasks/section2.yml
@@ -368,7 +368,7 @@
         lineinfile:
             dest: /etc/sysconfig/chronyd
             regexp: "^(#)?OPTIONS"
-            line: "OPTIONS=\"-u chrony\""
+            line: "OPTIONS=\"-u {{ chrony_system_user[ansible_os_family] }}\""
             state: present
             create: true
   when:


### PR DESCRIPTION
On Ubuntu, chrony user is '_chrony'

I do not have access to a plain Debian install, but I am assuming it is the same.

On RHEL, the original value of 'chrony' is correct.