### PR TITLE
Update filesystem usage for latest CIS benchmark

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -28,7 +28,6 @@ ubuntu2004cis_rule_1_1_1_4: true
 ubuntu2004cis_rule_1_1_1_5: true
 ubuntu2004cis_rule_1_1_1_6: true
 ubuntu2004cis_rule_1_1_1_7: true
-ubuntu2004cis_rule_1_1_1_8: false
 ubuntu2004cis_rule_1_1_2: true
 ubuntu2004cis_rule_1_1_3: true
 ubuntu2004cis_rule_1_1_4: true

--- a/tasks/section1.yml
+++ b/tasks/section1.yml
@@ -162,7 +162,39 @@
       - filesystems
       - rule_1.1.1.5
 
-- name: "SCORED | 1.1.1.6 | PATCH | Ensure mounting of udf filesystems is disabled"
+- name: "SCORED | 1.1.1.6 | PATCH | Ensure mounting of squashfs filesystems is disabled"
+  lineinfile:
+      dest: /etc/modprobe.d/CIS.conf
+      regexp: "^(#)?install squashfs(\\s|$)"
+      line: "install squashfs /bin/true"
+      state: present
+      create: true
+  when:
+      - ubuntu2004cis_rule_1_1_1_6
+  tags:
+      - level1
+      - scored
+      - patch
+      - squashfs
+      - filesystems
+      - rule_1.1.1.6
+
+- name: "SCORED | 1.1.1.6 | PATCH | Remove squashfs module"
+  modprobe:
+      name: squashfs
+      state: absent
+  when:
+      - ubuntu2004cis_rule_1_1_1_6
+      - not ubuntu2004cis_skip_for_travis
+  tags:
+      - level1
+      - scored
+      - patch
+      - squashfs
+      - filesystems
+      - rule_1.1.1.6
+
+- name: "SCORED | 1.1.1.7 | PATCH | Ensure mounting of udf filesystems is disabled"
   lineinfile:
       dest: /etc/modprobe.d/CIS.conf
       regexp: "^(#)?install udf(\\s|$)"
@@ -170,59 +202,27 @@
       state: present
       create: true
   when:
-      - ubuntu2004cis_rule_1_1_1_6
+      - ubuntu2004cis_rule_1_1_1_7
   tags:
       - level1
       - scored
       - patch
       - udf
       - filesystems
-      - rule_1.1.1.6
+      - rule_1.1.1.7
 
-- name: "SCORED | 1.1.1.6 | PATCH | Remove udf module"
+- name: "SCORED | 1.1.1.7 | PATCH | Remove udf module"
   modprobe:
       name: udf
       state: absent
   when:
-      - ubuntu2004cis_rule_1_1_1_6
+      - ubuntu2004cis_rule_1_1_1_7
       - not ubuntu2004cis_skip_for_travis
   tags:
       - level1
       - scored
       - patch
       - udf
-      - filesystems
-      - rule_1.1.1.6
-
-- name: "NOTSCORED | 1.1.1.7 | PATCH | Ensure mounting of FAT filesystems is limited"
-  lineinfile:
-      dest: /etc/modprobe.d/CIS.conf
-      regexp: "^(#)?install vfat(\\s|$)"
-      line: "install vfat /bin/true"
-      state: present
-      create: true
-  when:
-      - ubuntu2004cis_rule_1_1_1_7
-  tags:
-      - level2
-      - notscored
-      - patch
-      - vfat
-      - filesystems
-      - rule_1.1.1.7
-
-- name: "NOTSCORED | 1.1.1.7 | PATCH | Remove FAT module"
-  modprobe:
-      name: vfat
-      state: absent
-  when:
-      - ubuntu2004cis_rule_1_1_1_7
-      - not ubuntu2004cis_skip_for_travis
-  tags:
-      - level2
-      - notscored
-      - patch
-      - vfat
       - filesystems
       - rule_1.1.1.7
 


### PR DESCRIPTION
Removes fat (unscored), and adds squashfs to the list of filesystems to be disabled. 

NOTE: If you use snap, you would likely want to disable the new 1.1.1.7 rule.